### PR TITLE
rename output params

### DIFF
--- a/core/src/at.h
+++ b/core/src/at.h
@@ -49,7 +49,7 @@ typedef struct {
 
 // Model
 AT_Result AT_model_create(
-    AT_Model **model,
+    AT_Model **out_model,
     const char *filepath
 );
 
@@ -58,13 +58,13 @@ void AT_model_destroy(
 );
 
 void AT_model_to_AABB(
-    AT_AABB *aabb,
+    AT_AABB *out_aabb,
     const AT_Model *model
 );
 
 // Scene
 AT_Result AT_scene_create(
-    AT_Scene **scene,
+    AT_Scene **out_scene,
     const AT_SceneConfig* config
 );
 
@@ -75,7 +75,7 @@ void AT_scene_destroy(
 // Simulation
 // Creates the simulation "object" and allocates voxel memory
 AT_Result AT_simulation_create(
-    AT_Simulation **simulation,
+    AT_Simulation **out_simulation,
     const AT_Scene *scene,
     const AT_Settings *settings
 );


### PR DESCRIPTION
previously, the output parameters in at.h (those that were being assigned by pass-by-pointer) were just named exactly what they were, without specifying that they were the "output" for example:
```
at_create_scene(--> AT_Scene **scene <-- ...)
```
naming it simply "scene" in this case clashes when you actually create and allocate the scene internally, so to avoid confusion these parameters should be named `out_X`.