### PR TITLE
create at_internal.h

### DIFF
--- a/core/src/at_internal.h
+++ b/core/src/at_internal.h
@@ -1,0 +1,28 @@
+/*
+ * any types that are forward declared in at.h can be fully defined here, as opposed to its .c file
+ * allows for easy includes between any src file
+ */
+
+#ifndef AT_INTERNAL_H
+#define AT_INTERNAL_H
+
+#include "acoustic/at.h"
+#include "acoustic/at_math.h"
+
+struct AT_Scene {
+    AT_Source *sources;
+    AT_AABB world_AABB;
+    uint32_t num_sources;
+    AT_Material material;
+    const AT_Model *environment;
+};
+
+struct AT_Model {
+    AT_Vec3 *vertices;
+    // TODO: normals
+    uint32_t *indices;
+    size_t vertex_count;
+    size_t index_count;
+};
+
+#endif // AT_INTERAL_H

--- a/core/src/at_model.c
+++ b/core/src/at_model.c
@@ -1,4 +1,5 @@
-#include "../include/acoustic/at_model.h"
+#include "acoustic/at_model.h"
+#include "../src/internal.h"
 
 #define CGLTF_IMPLEMENTATION
 
@@ -7,14 +8,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-struct AT_Model {
-    AT_Vec3 *vertices;
-    // TODO: normals
-    uint32_t *indices;
-    size_t vertex_count;
-    size_t index_count;
-};
-
 AT_Result AT_model_create(AT_Model **out_model, const char *filepath)
 {
     if (!out_model || *out_model || !filepath) return AT_ERR_INVALID_ARGUMENT;
@@ -22,28 +15,28 @@ AT_Result AT_model_create(AT_Model **out_model, const char *filepath)
     cgltf_options options = {0};
     cgltf_data *data = NULL;
     cgltf_result res = cgltf_parse_file(&options, filepath, &data);
-    
+
     if (res != cgltf_result_success) return AT_ERR_INVALID_ARGUMENT;
 
     res = cgltf_load_buffers(&options, data, filepath);
-    
+
     if (res != cgltf_result_success) {
         cgltf_free(data);
-        return AT_ERR_INVALID_ARGUMENT;       
+        return AT_ERR_INVALID_ARGUMENT;
     }
-    
+
     if (data->meshes_count == 0) {
         cgltf_free(data);
         return AT_ERR_INVALID_ARGUMENT;
     }
     cgltf_mesh *mesh = &data->meshes[0];
-    
+
     if (mesh->primitives_count == 0) {
         cgltf_free(data);
         return AT_ERR_INVALID_ARGUMENT;
     }
     cgltf_primitive *primitive = &mesh->primitives[0];
-    
+
     cgltf_accessor *pos_accessor = NULL;
     for (size_t i = 0; i < primitive->attributes_count; i++) {
         if (primitive->attributes[i].type == cgltf_attribute_type_position) {
@@ -51,30 +44,30 @@ AT_Result AT_model_create(AT_Model **out_model, const char *filepath)
             break;
         }
     }
-    
+
     if (!pos_accessor) {
         cgltf_free(data);
         return AT_ERR_INVALID_ARGUMENT;
     }
-    
+
     // Vertices
     size_t vertex_count = pos_accessor->count;
     AT_Vec3 *vertices = malloc(sizeof(AT_Vec3) * vertex_count);
-    
+
     if (!vertices) {
         cgltf_free(data);
         return AT_ERR_ALLOC_ERROR;
     }
-    
+
     for (size_t i = 0; i < vertex_count; i++) {
         float v[3];
         cgltf_accessor_read_float(pos_accessor, i, v, 3);
         vertices[i] = (AT_Vec3){ v[0], v[1], v[2] };
     }
-    
+
     // Indices
     cgltf_accessor *idx_accessor = primitive->indices;
-    
+
     if (!idx_accessor) {
         cgltf_free(data);
         free(vertices);
@@ -83,19 +76,19 @@ AT_Result AT_model_create(AT_Model **out_model, const char *filepath)
 
     size_t index_count = idx_accessor->count;
     uint32_t *indices = malloc(sizeof(uint32_t) * index_count);
-    
+
     if (!indices) {
         cgltf_free(data);
         free(vertices);
         return AT_ERR_ALLOC_ERROR;
     }
-    
+
     for (size_t i = 0; i < index_count; i++) {
         uint32_t idx = 0;
         cgltf_accessor_read_uint(idx_accessor, i, &idx, 1);
         indices[i] = idx;
     }
-    
+
     AT_Model *model = calloc(1, sizeof(AT_Model));
     if (!model) {
         cgltf_free(data);
@@ -103,14 +96,14 @@ AT_Result AT_model_create(AT_Model **out_model, const char *filepath)
         free(indices);
         return AT_ERR_ALLOC_ERROR;
     }
-    
+
     model->index_count = index_count;
     model->vertex_count = vertex_count;
     model->indices = indices;
     model->vertices = vertices;
-    
+
     *out_model = model;
-    
+
     cgltf_free(data);
     return AT_OK;
 }
@@ -121,5 +114,5 @@ void AT_model_destroy(AT_Model *model)
 
    free(model->vertices);
    free(model->indices);
-   free(model); 
+   free(model);
 }

--- a/core/src/at_scene.c
+++ b/core/src/at_scene.c
@@ -1,17 +1,12 @@
 #include "acoustic/at_scene.h"
 #include "acoustic/at.h"
+#include "../src/at_internal.h"
 
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
-struct AT_Scene {
-    AT_Source *sources;
-    AT_AABB world_AABB;
-    uint32_t num_sources;
-    AT_Material material;
-    const AT_Model *environment;
-};
+
 
 AT_Result AT_scene_create(AT_Scene **out_scene, const AT_SceneConfig* config)
 {


### PR DESCRIPTION
any types that are forward declared in at.h can be fully defined here, as opposed to its respective .c file

allows for easy includes between any src file
 
for example I needed the AT_Scene definition in at_simulation, which was defined in at_scene.c, so instead of me including the .c file, or sacrificing encapsulation by defining in a header in acoustic/, we can store these internally in src