### PR TITLE
Remove double declared function

### DIFF
--- a/core/src/at_model.c
+++ b/core/src/at_model.c
@@ -233,14 +233,3 @@ AT_Result AT_model_get_triangles(AT_Triangle **out_triangles, const AT_Model *mo
     *out_triangles = ts;
     return AT_OK;
 }
-
-
-void AT_model_destroy(AT_Model *model)
-{
-   if (!model) return;
-
-   free(model->vertices);
-   free(model->indices);
-   free(model->normals);
-   free(model);
-}


### PR DESCRIPTION
A merge error resulted in AT_model_destroy being declared twice so I'm removing the second one.