### PR TITLE
Refactor vectors to be union of struct and array

### DIFF
--- a/core/include/acoustic/at_math.h
+++ b/core/include/acoustic/at_math.h
@@ -10,8 +10,11 @@
 
 /** \brief Groups three floats to represent a vector of size 3.
  */
-typedef struct {
-    float x, y, z;
+typedef union {
+    struct {
+        float x, y, z;
+    };
+    float arr[3];
 } AT_Vec3;
 
 typedef struct {
@@ -37,7 +40,7 @@ typedef struct {
 */
 static inline AT_Vec3 AT_vec3(float x, float y, float z)
 {
-    return (AT_Vec3){ x, y, z };
+    return (AT_Vec3){{x, y, z}};
 }
 
 /** \brief AT_Vec3 constructor for a zero initialised vector.
@@ -47,7 +50,7 @@ static inline AT_Vec3 AT_vec3(float x, float y, float z)
 */
 static inline AT_Vec3 AT_vec3_zero(void)
 {
-    return (AT_Vec3){ 0.0f, 0.0f, 0.0f };
+    return (AT_Vec3){{0.0f, 0.0f, 0.0f}};
 }
 
 /** \brief Adds two AT_Vec3.
@@ -57,7 +60,7 @@ static inline AT_Vec3 AT_vec3_zero(void)
 */
 static inline AT_Vec3 AT_vec3_add(AT_Vec3 a, AT_Vec3 b)
 {
-    return (AT_Vec3){ a.x + b.x, a.y + b.y, a.z + b.z };
+    return (AT_Vec3){{a.x + b.x, a.y + b.y, a.z + b.z}};
 }
 
 /** \brief Subtracts two AT_Vec3.
@@ -67,7 +70,7 @@ static inline AT_Vec3 AT_vec3_add(AT_Vec3 a, AT_Vec3 b)
 */
 static inline AT_Vec3 AT_vec3_sub(AT_Vec3 a, AT_Vec3 b)
 {
-    return (AT_Vec3){ a.x - b.x, a.y - b.y, a.z - b.z };
+    return (AT_Vec3){{a.x - b.x, a.y - b.y, a.z - b.z}};
 }
 
 /** \brief Product of two AT_Vec3.
@@ -77,7 +80,7 @@ static inline AT_Vec3 AT_vec3_sub(AT_Vec3 a, AT_Vec3 b)
 */
 static inline AT_Vec3 AT_vec3_mul(AT_Vec3 a, AT_Vec3 b)
 {
-    return (AT_Vec3){ a.x * b.x, a.y * b.y, a.z * b.z };
+    return (AT_Vec3){{a.x * b.x, a.y * b.y, a.z * b.z}};
 }
 
 /** \brief Calculates the inverse of a vector.
@@ -88,9 +91,9 @@ static inline AT_Vec3 AT_vec3_mul(AT_Vec3 a, AT_Vec3 b)
 static inline AT_Vec3 AT_vec3_inv(AT_Vec3 v)
 {
     return (AT_Vec3){
-        v.x != 0.0f ? 1.0f / v.x : FLT_MAX,
-        v.y != 0.0f ? 1.0f / v.y : FLT_MAX,
-        v.z != 0.0f ? 1.0f / v.z : FLT_MAX
+        {v.x != 0.0f ? 1.0f / v.x : FLT_MAX,
+         v.y != 0.0f ? 1.0f / v.y : FLT_MAX,
+         v.z != 0.0f ? 1.0f / v.z : FLT_MAX}
     };
 }
 
@@ -104,7 +107,7 @@ static inline AT_Vec3 AT_vec3_inv(AT_Vec3 v)
 */
 static inline AT_Vec3 AT_vec3_scale(AT_Vec3 v, float s)
 {
-    return (AT_Vec3){ v.x * s, v.y * s, v.z * s };
+    return (AT_Vec3){{v.x * s, v.y * s, v.z * s}};
 }
 
 /** \brief Performs vector dot operation on two given AT_Vec3.
@@ -125,9 +128,10 @@ static inline float AT_vec3_dot(AT_Vec3 a, AT_Vec3 b)
 static inline AT_Vec3 AT_vec3_cross(AT_Vec3 a, AT_Vec3 b)
 {
     return (AT_Vec3){
-        a.y * b.z - a.z * b.y,
-        a.z * b.x - a.x * b.z,
-        a.x * b.y - a.y * b.x};
+        {a.y * b.z - a.z * b.y,
+         a.z * b.x - a.x * b.z,
+         a.x * b.y - a.y * b.x}
+    };
 }
 
 /** \brief Calculate the length of an AT_Vec3.
@@ -183,9 +187,9 @@ static inline float AT_vec3_distance_sq(AT_Vec3 a, AT_Vec3 b)
 static inline AT_Vec3 AT_vec3_delta(AT_Vec3 v)
 {
     return (AT_Vec3){
-        v.x != 0.0f ? fabsf(1.0f / v.x) : FLT_MAX,
-        v.y != 0.0f ? fabsf(1.0f / v.y) : FLT_MAX,
-        v.z != 0.0f ? fabsf(1.0f / v.z) : FLT_MAX
+        {v.x != 0.0f ? fabsf(1.0f / v.x) : FLT_MAX,
+         v.y != 0.0f ? fabsf(1.0f / v.y) : FLT_MAX,
+         v.z != 0.0f ? fabsf(1.0f / v.z) : FLT_MAX}
     };
 }
 

--- a/core/src/at_aabb.c
+++ b/core/src/at_aabb.c
@@ -15,16 +15,16 @@ AT_Vec3 AT_AABB_calc_midpoint(AT_AABB *aabb)
 AT_AABB AT_AABB_from_triangle(const AT_Triangle *tri)
 {
     AT_AABB out_aabb;
-    out_aabb.min = (AT_Vec3){
+    out_aabb.min = (AT_Vec3){{
         AT_min(AT_min(tri->v1.x, tri->v2.x), tri->v3.x),
         AT_min(AT_min(tri->v1.y, tri->v2.y), tri->v3.y),
         AT_min(AT_min(tri->v1.z, tri->v2.z), tri->v3.z),
-    };
-    out_aabb.max = (AT_Vec3){
+    }};
+    out_aabb.max = (AT_Vec3){{
         AT_max(AT_max(tri->v1.x, tri->v2.x), tri->v3.x),
         AT_max(AT_max(tri->v1.y, tri->v2.y), tri->v3.y),
         AT_max(AT_max(tri->v1.z, tri->v2.z), tri->v3.z),
-    };
+    }};
     out_aabb.midpoint = AT_AABB_calc_midpoint(&out_aabb);
 
     return out_aabb;

--- a/core/src/at_aabb.h
+++ b/core/src/at_aabb.h
@@ -24,12 +24,12 @@ void AT_AABB_grow(AT_AABB *out_aabb, AT_Vec3 pt);
 static inline AT_AABB AT_AABB_join(AT_AABB a, AT_AABB b)
 {
     AT_AABB out_aabb;
-    out_aabb.min = (AT_Vec3){AT_min(a.min.x, b.min.y),
+    out_aabb.min = (AT_Vec3){{AT_min(a.min.x, b.min.y),
                              AT_min(a.min.y, b.min.y),
-                             AT_min(a.min.z, b.min.z)};
-    out_aabb.max = (AT_Vec3){AT_max(a.max.x, b.max.y),
+                             AT_min(a.min.z, b.min.z)}};
+    out_aabb.max = (AT_Vec3){{AT_max(a.max.x, b.max.y),
                              AT_max(a.max.y, b.max.y),
-                             AT_max(a.max.z, b.max.z)};
+                             AT_max(a.max.z, b.max.z)}};
     out_aabb.midpoint = AT_AABB_calc_midpoint(&out_aabb);
 
     return out_aabb;

--- a/core/src/at_model.c
+++ b/core/src/at_model.c
@@ -142,10 +142,9 @@ AT_Result AT_model_create(AT_Model **out_model, const char *filepath)
         for (size_t i = 0; i < vertex_count; i++) {
             float v[3];
             cgltf_accessor_read_float(pos_accessor, i, v, 3);
-            vertices[vertex_index + i] = (AT_Vec3){ v[0], v[1], v[2] };
+            vertices[vertex_index + i] = (AT_Vec3){{v[0], v[1], v[2]}};
         }
         vertex_index += vertex_count;
-
 
         // Indices
         cgltf_accessor *idx_accessor = primitive->indices;
@@ -173,7 +172,7 @@ AT_Result AT_model_create(AT_Model **out_model, const char *filepath)
         for (size_t i = 0; i < norm_accessor->count; i++) {
             float n[3];
             cgltf_accessor_read_float(norm_accessor, i, n, 3);
-            normals[normal_index + i] = (AT_Vec3){ n[0], n[1], n[2]};
+            normals[normal_index + i] = (AT_Vec3){{n[0], n[1], n[2]}};
         }
         normal_index += norm_accessor->count;
     }

--- a/core/src/at_utils.h
+++ b/core/src/at_utils.h
@@ -133,11 +133,11 @@ static inline int AT_get_sign_float(const float f)
 
 static inline AT_Vec3 AT_get_sign_vec3(const AT_Vec3 v)
 {
-   return (AT_Vec3){
+   return (AT_Vec3){{
        AT_get_sign_float(v.x),
        AT_get_sign_float(v.y),
        AT_get_sign_float(v.z)
-   };
+   }};
 }
 
 #endif //AT_UTILS_H


### PR DESCRIPTION
This PR refactors the `AT_Vec3` struct to be union of the original struct and an array of three floats.
The `x`, `y`, and `z` values are still accessed in the same way,
the only change is that an `AT_Vec3` should be created with double `{{}}` instead of `{}`, like such:

```c
AT_Vec3 vec = (AT_Vec3){{1.0f, 1.0f, 1.0f}};
```
